### PR TITLE
Replace account address with its name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ yarn-error.log*
 
 .env
 .vscode
+.idea
 
 # runtime config
 public/chainbridge-runtime-config.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Implemented transfer tx links to source, destination chains during tokens transfer
+- Replace account address with its name on the select account dropdown
 
 ## v0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## vNext
 
 - Implemented transfer tx links to source, destination chains during tokens transfer
-- Replace account address with its name on the select account dropdown
+- Replaced account address with its name on the select account dropdown
 
 ## v0.16.0
 

--- a/src/Components/Pages/TransferPage.tsx
+++ b/src/Components/Pages/TransferPage.tsx
@@ -630,7 +630,7 @@ const TransferPage = () => {
                         label="Select account"
                         className={classes.generalInput}
                         options={accounts.map((acc, i) => ({
-                          label: acc.address,
+                          label: acc.meta.addressName,
                           value: i,
                         }))}
                         onChange={(value) =>

--- a/src/Components/Pages/TransferPage.tsx
+++ b/src/Components/Pages/TransferPage.tsx
@@ -630,7 +630,7 @@ const TransferPage = () => {
                         label="Select account"
                         className={classes.generalInput}
                         options={accounts.map((acc, i) => ({
-                          label: acc.meta.addressName,
+                          label: acc.meta.name,
                           value: i,
                         }))}
                         onChange={(value) =>

--- a/src/Contexts/Adaptors/SubstrateHomeAdaptor.tsx
+++ b/src/Contexts/Adaptors/SubstrateHomeAdaptor.tsx
@@ -189,6 +189,7 @@ export const SubstrateHomeAdaptorProvider = ({
                 meta: {
                   ...meta,
                   name: `${meta.name} (${meta.source})`,
+                  addressName: meta.name,
                 },
               }));
             })

--- a/src/Contexts/Adaptors/SubstrateHomeAdaptor.tsx
+++ b/src/Contexts/Adaptors/SubstrateHomeAdaptor.tsx
@@ -4,13 +4,11 @@ import { useNetworkManager } from "../NetworkManagerContext";
 import { createApi, submitDeposit } from "./SubstrateApis/ChainBridgeAPI";
 import { IHomeBridgeProviderProps, InjectedAccountType } from "./interfaces";
 
-import { ApiPromise } from "@polkadot/api";
 import {
   web3Accounts,
   web3Enable,
   web3FromSource,
 } from "@polkadot/extension-dapp";
-import { TypeRegistry } from "@polkadot/types";
 import { Tokens } from "@chainsafe/web3-context/dist/context/tokensReducer";
 import { BigNumber as BN } from "bignumber.js";
 import { VoidFn } from "@polkadot/api/types";
@@ -188,8 +186,7 @@ export const SubstrateHomeAdaptorProvider = ({
                 address,
                 meta: {
                   ...meta,
-                  name: `${meta.name} (${meta.source})`,
-                  addressName: meta.name,
+                  name: meta.name || address,
                 },
               }));
             })

--- a/src/Contexts/Adaptors/interfaces.tsx
+++ b/src/Contexts/Adaptors/interfaces.tsx
@@ -17,7 +17,6 @@ export interface IWeb3ProviderWrapper {
 export type InjectedAccountType = {
   address: string;
   meta: {
-    addressName?: string;
     name: string;
     source: string;
   };

--- a/src/Contexts/Adaptors/interfaces.tsx
+++ b/src/Contexts/Adaptors/interfaces.tsx
@@ -17,6 +17,7 @@ export interface IWeb3ProviderWrapper {
 export type InjectedAccountType = {
   address: string;
   meta: {
+    addressName?: string;
     name: string;
     source: string;
   };


### PR DESCRIPTION
Replace account address with its name in the select account dropdown
https://cerenetwork.atlassian.net/browse/CBI-2095

## Description
I decided to create new prop `addressName` because it's hard to track where `name` is used and it might be unsafe to update it.
