### PR TITLE
Fix transfer page after wallet disconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed preflight check misaligned issue
 - Fixed WalletConnect login issue after auth popup was closed
 - Fixed app transfer page reset after mobile restart
+- Fixed transfer page reset after provider disconnection
 
 ## v0.20.0
 

--- a/src/Contexts/ChainbridgeContext.tsx
+++ b/src/Contexts/ChainbridgeContext.tsx
@@ -87,6 +87,7 @@ const ChainbridgeProvider = ({
     setTransferTxHash,
     setHomeTransferTxHash,
     setAddress,
+    setWalletType
   } = useNetworkManager();
 
   const {
@@ -122,6 +123,8 @@ const ChainbridgeProvider = ({
     setAddress(undefined);
     setTransferTxHash(undefined);
     setHomeTransferTxHash(undefined);
+    const disconnected = !isReady && transactionStatus === "Transfer Completed";
+    if (disconnected) setWalletType('unset');
   };
 
   const handleDeposit = useCallback(

--- a/src/Contexts/ChainbridgeContext.tsx
+++ b/src/Contexts/ChainbridgeContext.tsx
@@ -123,8 +123,7 @@ const ChainbridgeProvider = ({
     setAddress(undefined);
     setTransferTxHash(undefined);
     setHomeTransferTxHash(undefined);
-    const disconnected = !isReady && transactionStatus === "Transfer Completed";
-    if (disconnected) setWalletType('unset');
+    if (!isReady) setWalletType('unset');
   };
 
   const handleDeposit = useCallback(


### PR DESCRIPTION
While testing on DEV found that I can't select the wallet type on the transfer page after WalletConnect transfer and mobile app restart.